### PR TITLE
Further README updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+We encourage contributions that continue to address the intended audience and
+design of this project. Bear in mind that this is primarily a teaching tool for
+using Git together with Godot, and so has a deliberately narrow scope.
+
+### Development environment
+
+Please use [pre-commit](https://pre-commit.com) to check for correct formatting
+and other issues before creating commits. To do this automatically, you can add
+it as a git hook:
+
+```
+# If you don't have pre-commit already:
+pip install pre-commit
+
+# Setup git hook:
+pre-commit install
+```
+
+Now `pre-commit` will run automatically on `git commit`!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Moddable Platformer
 
-This project is a simple game created by [Endless Access](https://access.endlessstudios.com) to help ease the learning curve into collaborative game design and development. 
-It is intended to be used as practice content for learning Git and GitHub collaboration.
+This project is a simple game created by [Endless
+Access](https://access.endlessstudios.com) to help ease the learning curve into
+collaborative game design and development.
 
+It is intended to be used as practice content for learning Git and GitHub
+collaboration.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Moddable Platformer
+# Threadbare Origins: InkDrinker
 
 This project is a simple game created by [Endless
 Access](https://access.endlessstudios.com) to help ease the learning curve into
@@ -7,26 +7,5 @@ collaborative game design and development.
 It is intended to be used as practice content for learning Git and GitHub
 collaboration.
 
-## Contributing
-
-We encourage contributions that continue to address the intended audience and
-design of of this project. You can communicate with us through the
-[Endless Studios](https://studio.endlessstudios.com/studio/games/Moddable-Platformer/)
-community platform and submit pull requests via
-[GitHub](https://github.com/endlessm/moddable-platformer).
-
-### Development environment
-
-Please use [pre-commit](https://pre-commit.com) to check for correct formatting
-and other issues before creating commits. To do this automatically, you can add
-it as a git hook:
-
-```
-# If you don't have pre-commit already:
-pip install pre-commit
-
-# Setup git hook:
-pre-commit install
-```
-
-Now `pre-commit` will run automatically on `git commit`!
+Thematically, it is an origin story for the InkDrinker antagonists in
+[Threadbare](https://github.com/endlessm/threadbare/).


### PR DESCRIPTION
This gets rid of references to Moddable Platformer; moves the contributing guidelines to a separate file; and gives some context for the name of the repo.

It should also fix the linter error introduced by #6 